### PR TITLE
added new error handler

### DIFF
--- a/Example/FunNet.xcodeproj/project.pbxproj
+++ b/Example/FunNet.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
+		642213F62660437500DF5993 /* NetworkErrorHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 642213F52660437500DF5993 /* NetworkErrorHandlerTests.swift */; };
 		889989B8BCCA05BF1A5931D6 /* Pods_FunNet_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FBA774A6951E3E68E49E63A /* Pods_FunNet_Tests.framework */; };
 		981B1CA625957EF200563103 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		B5C47F4263F9B7C7AE4E4667 /* Pods_FunNet_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A86C6F6AAFC21B5CAA312BD7 /* Pods_FunNet_Example.framework */; };
@@ -54,6 +55,7 @@
 		607FACDF1AFB9204008FA782 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		607FACE51AFB9204008FA782 /* FunNet_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FunNet_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		642213F52660437500DF5993 /* NetworkErrorHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorHandlerTests.swift; sourceTree = "<group>"; };
 		6B9F70714EC46F1B21F821FD /* Pods-FunNet_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FunNet_Example.debug.xcconfig"; path = "Target Support Files/Pods-FunNet_Example/Pods-FunNet_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		8AA50C881868927D56BD7771 /* Pods-FunNet_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FunNet_Example.release.xcconfig"; path = "Target Support Files/Pods-FunNet_Example/Pods-FunNet_Example.release.xcconfig"; sourceTree = "<group>"; };
 		96D6CBE6F79C3B5146ACB9A2 /* Pods-FunNet_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FunNet_Tests.release.xcconfig"; path = "Target Support Files/Pods-FunNet_Tests/Pods-FunNet_Tests.release.xcconfig"; sourceTree = "<group>"; };
@@ -149,6 +151,7 @@
 				493008C1242B9F8300241C1A /* RequestTests.swift */,
 				493008C3242BA7C300241C1A /* ResponderTests.swift */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
+				642213F52660437500DF5993 /* NetworkErrorHandlerTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -337,15 +340,19 @@
 				"${PODS_ROOT}/Target Support Files/Pods-FunNet_Example/Pods-FunNet_Example-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/FunNet/FunNet.framework",
 				"${BUILT_PRODUCTS_DIR}/LithoOperators/LithoOperators.framework",
+				"${BUILT_PRODUCTS_DIR}/LithoUtils/LithoUtils.framework",
 				"${BUILT_PRODUCTS_DIR}/Prelude/Prelude.framework",
 				"${BUILT_PRODUCTS_DIR}/ReactiveSwift/ReactiveSwift.framework",
+				"${BUILT_PRODUCTS_DIR}/fuikit/fuikit.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FunNet.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/LithoOperators.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/LithoUtils.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Prelude.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ReactiveSwift.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/fuikit.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -372,6 +379,7 @@
 			files = (
 				49DFCD792565810A000AD926 /* MultipartTests.swift in Sources */,
 				49CEE0A6242390AA00F5E124 /* ServerConfigurationTests.swift in Sources */,
+				642213F62660437500DF5993 /* NetworkErrorHandlerTests.swift in Sources */,
 				496378A325B895B50020E60B /* MultipartNamingTests.swift in Sources */,
 				493008C2242B9F8300241C1A /* RequestTests.swift in Sources */,
 				493008C4242BA7C300241C1A /* ResponderTests.swift in Sources */,
@@ -453,7 +461,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -500,7 +508,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -515,6 +523,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = FunNet/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
@@ -530,6 +539,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = FunNet/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,9 +1,11 @@
 use_frameworks!
-platform :ios, '10.0'
+platform :ios, '11.0'
 
 target 'FunNet_Example' do
   pod 'FunNet', :path => '../'
-
+  pod 'LithoOperators', git: 'https://github.com/ThryvInc/LithoOperators'
+  pod 'LithoUtils/Core', git: 'https://github.com/ThryvInc/litho-utils'
+  
   target 'FunNet_Tests' do
     inherit! :search_paths
   end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,42 +1,69 @@
 PODS:
-  - FunNet (0.0.1):
-    - FunNet/Combine (= 0.0.1)
-    - FunNet/Core (= 0.0.1)
-    - FunNet/Multipart (= 0.0.1)
-    - FunNet/ReactiveSwift (= 0.0.1)
+  - fuikit (0.1.5):
+    - fuikit/Core (= 0.1.5)
+    - fuikit/CoreBluetooth (= 0.1.5)
+    - fuikit/CoreLocation (= 0.1.5)
+  - fuikit/Core (0.1.5)
+  - fuikit/CoreBluetooth (0.1.5)
+  - fuikit/CoreLocation (0.1.5)
+  - FunNet (0.1.1):
+    - FunNet/Combine (= 0.1.1)
+    - FunNet/Core (= 0.1.1)
+    - FunNet/Multipart (= 0.1.1)
+    - FunNet/ReactiveSwift (= 0.1.1)
     - LithoOperators
-  - FunNet/Core (0.0.1):
+  - FunNet/Core (0.1.1):
     - LithoOperators
-  - FunNet/Multipart (0.0.1):
+    - LithoUtils/Core
+  - FunNet/Multipart (0.1.1):
     - LithoOperators
-  - FunNet/ReactiveSwift (0.0.1):
+  - FunNet/ReactiveSwift (0.1.1):
     - FunNet/Core
     - LithoOperators
     - ReactiveSwift
-  - LithoOperators (0.0.2):
+  - LithoOperators (0.1.4):
     - Prelude
+  - LithoUtils/Core (0.1.0):
+    - fuikit
+    - LithoOperators
   - Prelude (3.0.0)
-  - ReactiveSwift (6.2.1)
+  - ReactiveSwift (6.6.0)
 
 DEPENDENCIES:
   - FunNet (from `../`)
+  - LithoOperators (from `https://github.com/ThryvInc/LithoOperators`)
+  - LithoUtils/Core (from `https://github.com/ThryvInc/litho-utils`)
 
 SPEC REPOS:
   trunk:
-    - LithoOperators
+    - fuikit
     - Prelude
     - ReactiveSwift
 
 EXTERNAL SOURCES:
   FunNet:
     :path: "../"
+  LithoOperators:
+    :git: https://github.com/ThryvInc/LithoOperators
+  LithoUtils:
+    :git: https://github.com/ThryvInc/litho-utils
+
+CHECKOUT OPTIONS:
+  LithoOperators:
+    :commit: a39bdd37f06f50e8284d94dbcd13caf116883cde
+    :git: https://github.com/ThryvInc/LithoOperators
+  LithoUtils:
+    :commit: 3948a64e5c27163c16a7d82f05071e52f5bbdd09
+    :git: https://github.com/ThryvInc/litho-utils
 
 SPEC CHECKSUMS:
-  FunNet: e01c3f3e4258f64657bdb2476236e064db2cd9b9
-  LithoOperators: 8a4f284d8c10cb02b28af87c18494ba225345419
+  fuikit: 976080e1c04037e01d14541135a104cb208d8c0d
+  FunNet: 039c0efaa7b69766ba5873e7fda11cbc41e4810b
+  LithoOperators: 8fc0c6a49e34a8d1ca01b777844f58e36c062d9f
+  LithoUtils: 3d89146680c1a7449334069cc75a092c32dde585
   Prelude: fe4cc0fd961d34edf48fe6b04d05c863449efb0a
-  ReactiveSwift: 07ddf579f4eb3ee3bd656214f0461aaf2c0fd639
+  ReactiveSwift: be9407e2aaf8a11e53a5229255693cffd9a63ccf
 
-PODFILE CHECKSUM: 7cb893b39fb1b5800d66e86e4732dc00ae9870e4
+PODFILE CHECKSUM: b07e2c6eeabf547c5be0e85562f614c6ef55972f
 
 COCOAPODS: 1.10.0

--- a/Example/Tests/NetworkErrorHandlerTests.swift
+++ b/Example/Tests/NetworkErrorHandlerTests.swift
@@ -1,0 +1,46 @@
+//
+//  NetworkErrorHandlerTests.swift
+//  FunNet_Tests
+//
+//  Created by Calvin Collins on 5/27/21.
+//  Copyright © 2021 CocoaPods. All rights reserved.
+//
+
+import XCTest
+@testable import FunNet
+
+class NetworkErrorHandlerTests: XCTestCase {
+    func testHandlerForStatusCode() {
+        let loginHandler = NetworkErrHandler<Int>(ErrorHandlingContext([.print]), supercedingHandlers: [], id: 2, errorMessageMap: [401: "Username or password incorrect."])
+        let adminHandler = NetworkErrHandler<Int>(ErrorHandlingContext([.print]), supercedingHandlers: [], id: 1, errorMessageMap: [401: "User is not admin"])
+        let generalHandler = NetworkErrHandler<Int>(ErrorHandlingContext([.print]), supercedingHandlers: [loginHandler], id: 0, errorMessageMap: [401: "User unauthorized", 404: "Not found"])
+        let generalHandler2 = NetworkErrHandler<Int>(ErrorHandlingContext([.print]), supercedingHandlers: [loginHandler, adminHandler], id: 3, errorMessageMap: [401: "User unauthorized"])
+        //Error Handled, no children
+        XCTAssertNotNil(loginHandler.handler(for: 401))
+        XCTAssertEqual(loginHandler.handler(for: 401)!.id, loginHandler.id)
+        //Error Handled, with supercedence
+        XCTAssertNotNil(generalHandler.handler(for: 401))
+        XCTAssertEqual(generalHandler.handler(for: 401)!.id, loginHandler.id)
+        //Error Handled, with supercedence, and handling conflict
+        XCTAssertNotNil(generalHandler2.handler(for: 401))
+        XCTAssertEqual(generalHandler2.handler(for: 401)!.id, adminHandler.id)
+        //Error not handled
+        XCTAssertNil(adminHandler.handler(for: 402))
+    }
+    
+    func testMessages() {
+        let loginHandler = NetworkErrHandler<Int>(ErrorHandlingContext([.print]), supercedingHandlers: [], id: 2, errorMessageMap: [401: "Username or password incorrect."])
+        let adminHandler = NetworkErrHandler<Int>(ErrorHandlingContext([.print]), supercedingHandlers: [], id: 1, errorMessageMap: [401: "User is not admin"])
+        let generalHandler = NetworkErrHandler<Int>(ErrorHandlingContext([.print]), supercedingHandlers: [loginHandler], id: 0, errorMessageMap: [401: "User unauthorized", 404: "Not found"])
+        let generalHandler2 = NetworkErrHandler<Int>(ErrorHandlingContext([.print]), supercedingHandlers: [loginHandler, adminHandler], id: 3, errorMessageMap: [401: "User unauthorized"])
+        
+        XCTAssertNotNil(loginHandler.message(for: 401))
+        XCTAssertEqual(loginHandler.message(for: 401)!, "Username or password incorrect.")
+        
+        XCTAssertNotNil(generalHandler.message(for: 401))
+        XCTAssertEqual(generalHandler.message(for: 401)!, "Username or password incorrect.")
+        
+        XCTAssertNotNil(generalHandler2.message(for: 401))
+        XCTAssertEqual(generalHandler2.message(for: 401)!, "User is not admin")
+    }
+}

--- a/FunNet.podspec
+++ b/FunNet.podspec
@@ -22,7 +22,7 @@ TODO: Add long description of the pod here.
   s.source           = { :git => 'https://github.com/schrockblock/funnet.git', :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/elliot_schrock'
 
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '11.0'
 
   s.source_files = 'FunNet/Classes/**/*'
   s.dependency 'LithoOperators'
@@ -30,6 +30,7 @@ TODO: Add long description of the pod here.
   s.subspec 'Core' do |sp|
     sp.source_files = 'FunNet/Classes/Core/**/*.swift'
     sp.dependency 'LithoOperators'
+    sp.dependency 'LithoUtils/Core'
   end
   
   s.subspec 'Combine' do |sp|

--- a/FunNet/Classes/Core/DefaultNetworkErrorHandler.swift
+++ b/FunNet/Classes/Core/DefaultNetworkErrorHandler.swift
@@ -1,0 +1,259 @@
+//
+//  DefaultNetworkErrorHandler.swift
+//  FunNet
+//
+//  Created by Calvin Collins on 5/26/21.
+//
+
+import UIKit
+import LithoUtils
+import LithoOperators
+import Prelude
+
+public enum ErrorHandlingConfig: UInt8 {
+    case none = 0b0
+    case print = 0b1
+    case debug = 0b10
+    case production = 0b100
+}
+
+public func defaultErrorHandlingConfig() -> [ErrorHandlingConfig] {
+    if (isSimulator()) {
+        return [.print, .debug]
+    } else {
+        return [.print, .production]
+    }
+}
+
+public struct ErrorHandlingContext {
+    var config: UInt8
+    public init(_ configs: [ErrorHandlingConfig]) {
+        self.config = configs.map(\.rawValue).reduce(0, (|))
+    }
+}
+
+public protocol NetworkErrorFunctionProvider {
+    var errorMessageMap: [Int:String] { get set }
+    var serverErrorMessageMap: [Int:String] { get set }
+    func errorHandler(_ presenter: ((UIViewController) -> Void)?) -> (NSError?) -> Void
+    func errorDataHandler(_ presenter: ((UIViewController) -> Void)?) -> (Data?) -> Void
+    func serverErrorHandler(_ presenter: ((UIViewController) -> Void)?) -> (NSError?) -> Void
+}
+
+extension NetworkErrorFunctionProvider {
+    func errorHandler(_ presenter: ((UIViewController) -> Void)? = nil) -> (NSError?) -> Void {
+        return errorHandler(presenter)
+    }
+    
+    func errorDataHandler(_ presenter: ((UIViewController) -> Void)? = nil) -> (Data?) -> Void {
+        return errorDataHandler(presenter)
+    }
+    
+    func serverErrorHandler(_ presenter: ((UIViewController) -> Void)? = nil) -> (NSError?) -> Void {
+        return serverErrorHandler(presenter)
+    }
+}
+
+open class NetworkErrHandler<T: Comparable>: NetworkErrorFunctionProvider {
+    open var serverErrorMessageMap: [Int : String] = [:]
+    open var errorMessageMap: [Int : String] = [:]
+    public var config: UInt8
+    public var id: T
+    public var supercedingHandlers: [NetworkErrHandler<T>]
+    
+    public init(_ context: ErrorHandlingContext = ErrorHandlingContext(defaultErrorHandlingConfig()), supercedingHandlers: [NetworkErrHandler<T>] = [], id: T, errorMessageMap: [Int:String] = [:], serverErrorMap: [Int:String] = [:]) {
+        self.id = id
+        self.config = context.config
+        self.supercedingHandlers = supercedingHandlers
+        self.serverErrorMessageMap = serverErrorMap
+        self.errorMessageMap = errorMessageMap
+    }
+    
+    public func serverError(statusCode: Int?, with data: Data?) -> NSError {
+        if let data = data, let rubyMessage = try? JSONDecoder().decode(RubyError.self, from: data) {
+            return NSError(domain: "Server Error", code: statusCode ?? -1, userInfo: ["message": rubyMessage.message ?? ""])
+        }
+        return NSError(domain: "Server Error", code: statusCode ?? -1, userInfo: ["message": (data ?> (.utf8 >||> String.init) >>> coalesceNil(with: "")) ?? ""])
+    }
+    
+    public func generalErrorHandler(_ presenter: ((UIViewController) -> Void)?) -> (NSError?, NSError?, (Int?, Data?)) -> Void {
+        let errorFromResponse = serverError >>> errorToMessage
+        let combiner = tupleMap(optionalize(with: errorToMessage >>> ^\SimpleErrorMessage.description), optionalize(with: errorToMessage >>> ^\SimpleErrorMessage.description), optionalize(with: ~errorFromResponse >>> ^\SimpleErrorMessage.description)) >>> { [$0.0, $0.1, $0.2] }
+        return { err, serverErr, response in
+            switch reduce(arr: combiner((err, serverErr, response))) {
+            case .some(let arr):
+                if self.should(.print) {
+                    print(arr)
+                }
+                if self.should(.debug) {
+                    let errorString = arr.reduce("", { $0 + "\n\($1)" })
+                    presenter?(alertController(title: "Errors", message: errorString))
+                }
+            case .none:
+                break
+            }
+        }
+    }
+    
+    public func errorHandler(_ presenter: ((UIViewController) -> Void)? = nil) -> (NSError?) -> Void {
+        return { err in
+            guard let err = err, let handler = self.handler(for: err.code) else { return }
+            if handler.should(.print) {
+                print(self.errorToMessage(err: err).description)
+            }
+            if handler.should(.debug) || handler.should(.production) {
+                presenter?(handler.alert(for: handler.errorToMessage(err: err)))
+            }
+        }
+    }
+    
+    public func errorDataHandler(_ presenter: ((UIViewController) -> Void)? = nil) -> (Data?) -> Void {
+        return { data in
+            guard let data = data else { return }
+            let error = self.serverError(statusCode: nil, with: data)
+            if self.should(.print) {
+                print(self.errorToMessage(err: error).description)
+            }
+            if self.should(.debug) || self.should(.production) {
+                presenter?(self.alert(for: self.errorToMessage(err: error)))
+            }
+        }
+    }
+    
+    public func serverErrorHandler(_ presenter: ((UIViewController) -> Void)? = nil) -> (NSError?) -> Void {
+        return { err in
+            guard let err = err, let handler = self.handler(for: err.code) else { return }
+            if handler.should(.print) {
+                print(self.serverErrorToMessage(err: err).description)
+            }
+            if self.should(.debug) || self.should(.production) {
+                presenter?(self.alert(for: self.serverErrorToMessage(err: err)))
+            }
+        }
+    }
+    
+    public func handler(for id: T) -> NetworkErrHandler<T> where T: Comparable {
+        if let handler = supercedingHandlers.filter(^\.id >>> isEqualTo(id)).first {
+            return handler
+        } else {
+            return self
+        }
+    }
+    
+    public func handler(for status: Int) -> NetworkErrHandler<T>? {
+        if supercedingHandlers.count == 0 && !(errorMessageMap[status] != nil || serverErrorMessageMap[status] != nil) {
+            return nil
+        } else {
+            if supercedingHandlers.count > 0 {
+                return supercedingHandlers.compactMap({ $0.handler(for: status) }).sortedBy(keyPath: \NetworkErrHandler<T>.id).first
+            } else {
+                return self
+            }
+        }
+    }
+    
+    public func message(for status: Int) -> String? {
+        if let handler = handler(for: status) {
+            return status < 500 ? handler.errorMessageMap[status] : handler.serverErrorMessageMap[status]
+        } else {
+            return status < 500 ? errorMessageMap[status] : serverErrorMessageMap[status]
+        }
+    }
+    
+    public func should(_ config: ErrorHandlingConfig) -> Bool {
+        return self.config & config.rawValue != 0
+    }
+    
+    open func errorToMessage(err: NSError) -> SimpleErrorMessage {
+        if should(.debug) {
+            return SimpleErrorMessage(err)
+        } else {
+            return SimpleErrorMessage(title: "Uh oh!", message: message(for: err.code) ?? "Something went wrong!", forCode: err.code)
+        }
+    }
+    
+    open func serverErrorToMessage(err: NSError) -> SimpleErrorMessage {
+        if should(.debug) {
+            return SimpleErrorMessage(title: "Server Error", message: err.localizedDescription, forCode: err.code)
+        } else {
+            return SimpleErrorMessage(title: "Uh oh!", message: message(for: err.code) ?? "Something went wrong!", forCode: err.code)
+        }
+    }
+    
+    open func alert(for errorMsg: SimpleErrorMessage) -> UIAlertController {
+        if (should(.debug)) {
+            return alertController(title: "\(errorMsg.title): \(errorMsg.forCode)", message: errorMsg.message)
+        } else {
+            return alertController(title: "\(errorMsg.title)", message: errorMsg.message)
+        }
+    }
+}
+
+public class DefaultNetworkErrHandler<T: Comparable>: NetworkErrHandler<T> {
+    public override init(_ context: ErrorHandlingContext = ErrorHandlingContext(defaultErrorHandlingConfig()), supercedingHandlers: [NetworkErrHandler<T>] = [], id: T, errorMessageMap: [Int : String] = [:], serverErrorMap: [Int : String] = [:]) {
+        super.init(context, supercedingHandlers: supercedingHandlers, id: id, errorMessageMap: errorMessageMap, serverErrorMap: serverErrorMap)
+        self.errorMessageMap.merge(urlRequestErrorCodesDict, uniquingKeysWith: { first, _ in
+            return first
+        })
+        self.serverErrorMessageMap.merge(urlLoadingErrorCodesDict, uniquingKeysWith: { first, _ in
+            return first
+        })
+    }
+    
+    public init(_ context: ErrorHandlingContext = ErrorHandlingContext(defaultErrorHandlingConfig()), supercedingHandlers: [NetworkErrHandler<T>] = [], id: T) {
+        super.init(context, supercedingHandlers: supercedingHandlers, id: id, errorMessageMap: urlRequestErrorCodesDict, serverErrorMap: urlLoadingErrorCodesDict)
+    }
+}
+
+public struct RubyError: Codable {
+    let message: String?
+}
+
+extension SimpleErrorMessage: CustomStringConvertible {
+    public var description: String {
+        return "\(title): \(forCode), \(message)"
+    }
+    
+    init(_ err: NSError) {
+        self.title = err.domain
+        self.forCode = err.code
+        self.message = (err.userInfo["message"] as? String) ?? "Was unable to decode message."
+    }
+}
+
+public func optionalize<T, U>(with f: @escaping (T) -> U) -> (T?) -> Optional<[U]> {
+    return { t in
+        if t != nil {
+            return .some([f(t!)])
+        } else {
+            return .none
+        }
+    }
+}
+
+public func optionalize<T, U, V>(with f: @escaping ((T?, U?)) -> V) -> ((T?, U?)?) -> Optional<[V]> {
+    return { tuple in
+        if tuple != nil {
+            return .some([f(tuple!)])
+        } else {
+            return .none
+        }
+    }
+}
+
+public func combine<T>(a: Optional<[T]>, b: Optional<[T]>) -> Optional<[T]> {
+    switch (a, b) {
+    case (.some(let arr1), .some(let arr2)):
+        return .some(arr1 + arr2)
+    case (.some, .none):
+        return a
+    case (.none, .some):
+        return b
+    case (.none, .none):
+        return .none
+    }
+}
+
+public func reduce<T>(arr: [Optional<[T]>]) -> Optional<[T]> {
+    return arr.reduce(.none, combine)
+}

--- a/FunNet/Classes/Core/URLLoadingErrorHandler.swift
+++ b/FunNet/Classes/Core/URLLoadingErrorHandler.swift
@@ -48,6 +48,39 @@ public func urlLoadingErrorMessages() -> [ErrorMessage] {
     return errorMessages
 }
 
+let urlRequestErrorCodesDict: [Int:String] = [
+        400 : "Bad request",
+        401 : "Unauthorized",
+        402 : "Payment required",
+        403 : "Forbidden",
+        404 : "Not found",
+        405 : "HTTP Method not allowed",
+        406 : "Content type in Accept header is unavailable",
+        408 : "Request timed out",
+        409 : "Conflict in requested resource",
+        410 : "Resource is permanently unavailable",
+        411 : "Length required",
+        412 : "Precondition failed",
+        413 : "Payload too large",
+        414 : "URI too long",
+        415 : "Unsupported mediatype",
+        416 : "Range not satisfiable",
+        417 : "Expectation failed",
+        418 : "This server is, in fact, a teapot",
+        420 : "420 error, dank dude",
+        421 : "Unauthorized",
+        422 : "Unable to process payload",
+        429 : "Too many requests",
+        431 : "Headers too large",
+        451 : "Unavailable for legal reasons",
+        500 : "Internal server error",
+        501 : "This functionality is not implemented",
+        502 : "Bad internet gateway",
+        503 : "Server currently unavailable",
+        505 : "HTTP version not supported",
+        511 : "Network authentication required"
+    ]
+
 public class VerboseURLLoadingErrorHandler: NetworkErrorHandler {
     var errorMessages: [ErrorMessage] = urlLoadingErrorMessages()
     var errorMessageMap: [Int: ErrorMessage] {


### PR DESCRIPTION
Lotta stuff to unpack here, but essentially what is going on now is that in the constructor for an error handler you can optionally put in a list of more specific error handlers and I've made it generic with a Comparable type so that the user can just do .errorHandler() and we can resolve any precedence conflicts that may come about. Something like DefaultErrorHandler<Int>([LoginErrorHandler<Int>, AdminErrorHandler<Int>).errorFunction will delegate to the internal handlers for status codes that are handled by the more specific ones, and the comparable generic will be used to determine which error message we should use. The nuts and bolts for the Ruby Error stuff is also in there, but only for handling Response and Data, as well as just Data.