### PR TITLE
using dismissable alert instead of alertController

### DIFF
--- a/Sources/funnet/Core/NetworkErrorHandler.swift
+++ b/Sources/funnet/Core/NetworkErrorHandler.swift
@@ -48,14 +48,14 @@ public class VerboseNetworkErrorHandler: NetworkErrorHandler {
     open func alert(for error: NSError) -> UIViewController {
         print(error)
         if let message = errorMessageMap[error.code] {
-            return alertController(title: message.title, message: message.message)
+            return dismissableAlert(title: message.title, message: message.message)
         } else {
-            return alertController(title: "Error \(error.code)", message: "Description: \(error.debugDescription)\nInfo: \(error.userInfo)")
+            return dismissableAlert(title: "Error \(error.code)", message: "Description: \(error.debugDescription)\nInfo: \(error.userInfo)")
         }
     }
     
     open func notify(title: String, message: String) {
-        alertController(title: title, message: message).show(animated: true)
+        dismissableAlert(title: title, message: message).show(animated: true)
     }
 }
 

--- a/Sources/funnet/Core/URLLoadingErrorHandler.swift
+++ b/Sources/funnet/Core/URLLoadingErrorHandler.swift
@@ -100,9 +100,9 @@ public class VerboseURLLoadingErrorHandler: NetworkErrorHandler {
     open func alert(for error: NSError) -> UIViewController {
         print(error)
         if let message = errorMessageMap[error.code] {
-            return alertController(title: message.title, message: message.message)
+            return dismissableAlert(title: message.title, message: message.message)
         } else {
-            return alertController(title: "Error \(error.code)", message: "Description: \(error.debugDescription)\nInfo: \(error.userInfo)")
+            return dismissableAlert(title: "Error \(error.code)", message: "Description: \(error.debugDescription)\nInfo: \(error.userInfo)")
         }
     }
 }

--- a/Sources/funnet/ErrorHandling/ErrorAlerts.swift
+++ b/Sources/funnet/ErrorHandling/ErrorAlerts.swift
@@ -13,23 +13,23 @@ import Slippers
 import UIKit
 
 public func debugAlert(code: Int, errorMap: [Int: String]) -> UIAlertController {
-    return alertController(title: "Error: \(code)", message: errorMap[code] ?? "")
+    return dismissableAlert(title: "Error: \(code)", message: errorMap[code] ?? "")
 }
 public func prodAlert(code: Int, errorMap: [Int:String]) -> UIAlertController {
-    return alertController(title: "Something went wrong!", message: errorMap[code] ?? "")
+    return dismissableAlert(title: "Something went wrong!", message: errorMap[code] ?? "")
 }
 public func debugFunNetErrorDataAlert(code: Int?, error: FunNetErrorData?) -> UIAlertController? {
     return codeStringAlert(code: code, description: error?.message)
 }
 public func prodFunNetErrorDataAlert(error: FunNetErrorData?) -> UIAlertController? {
     if let err = error {
-        return alertController(title: "Something went wrong!", message: err.message ?? "")
+        return dismissableAlert(title: "Something went wrong!", message: err.message ?? "")
     }
     return nil
 }
 public func codeStringAlert(code: Int?, description: String?) -> UIAlertController? {
     if let code = code, let desc = description {
-        return alertController(title: "Error \(code)", message: desc)
+        return dismissableAlert(title: "Error \(code)", message: desc)
     } else {
         return nil
     }

--- a/Sources/funnet/ErrorHandling/ErrorData.swift
+++ b/Sources/funnet/ErrorHandling/ErrorData.swift
@@ -29,5 +29,5 @@ public func httpResponseToFunNetErrorData<T: FunNetErrorData>(type: T.Type) -> (
 }
 
 public func dataHandler(vc: UIViewController?) -> (Data?) -> Void {
-    return (dataToString >?> ("Error" *-> alertController(title:message:))) >?> vc?.presentClosure()
+    return (dataToString >?> ("Error" *-> (("Okay", { }) --**> dismissableAlert(title:message:actionTitle:onDismiss:)))) >?> vc?.presentClosure()
 }


### PR DESCRIPTION
I had to use the LithoUtils version of alert to get it compatible with SPM (some naming conflict, if I remember), and that alert doesn't have a dismiss button. JJ's work on error handling brought this problem to light and I made this branch for him that instead uses dismissableAlertController.